### PR TITLE
Feat: Add Video content type and initial documentation

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -105,7 +105,7 @@ blt-tokenize \
   --output  tokens.bin      # Path or '-' for stdout
   --merges  merges.txt      # Optional BPE merge rules
   --patch   patch.yml       # Optional patch config
-  --type    text|audio|bin  # Content-type token
+  --type    text|audio|bin|video  # Content-type token
   --threads 8               # Override worker count
   --memcap  80%             # Max RAM usage fraction
   --chunksize 4MB           # Min/Max chunk size bounds

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,38 @@
+# Contributing to Byte-Level Tokenizer (BLT)
+
+First off, thank you for considering contributing to BLT! Your help is greatly appreciated.
+
+## How Can I Contribute?
+
+### Reporting Bugs
+- Ensure the bug was not already reported by searching on GitHub under [Issues](https://github.com/username/blt/issues).
+- If you're unable to find an open issue addressing the problem, [open a new one](https://github.com/username/blt/issues/new). Be sure to include a title and clear description, as much relevant information as possible, and a code sample or an executable test case demonstrating the expected behavior that is not occurring.
+
+### Suggesting Enhancements
+- Open a new issue with the enhancement proposal. Clearly describe the intended feature and its benefits.
+
+### Pull Requests
+1.  Fork the repo and create your branch from `main`.
+2.  If you've added code that should be tested, add tests.
+3.  If you've changed APIs, update the documentation.
+4.  Ensure the test suite passes (`cargo test --all`).
+5.  Make sure your code lints (`cargo fmt` and `cargo clippy -- -D warnings`).
+6.  Issue that pull request!
+
+## Development Setup
+1.  Clone the repository: `git clone https://github.com/username/blt.git`
+2.  Install Rust: See [rustup.rs](https://rustup.rs/).
+3.  Ensure you have `cargo fmt` and `cargo clippy`:
+    ```bash
+    rustup component add rustfmt clippy
+    ```
+4.  Build the project: `cargo build`
+5.  Run tests: `cargo test --all`
+
+## Coding Standards
+Please review our [CODING_STANDARDS.md](./CODING_STANDARDS.md) for details on our coding style and principles.
+
+## Code of Conduct
+This project and everyone participating in it is governed by a Code of Conduct. By participating, you are expected to uphold this code. (Note: A formal Code of Conduct file should be added, e.g., Contributor Covenant).
+
+We look forward to your contributions!

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,17 @@
+# Stage 1: Build the application
+FROM rust:latest AS builder
+
+WORKDIR /usr/src/blt
+COPY . .
+
+# Build the release binary
+RUN cargo build --release
+
+# Stage 2: Create the runtime image
+FROM debian:slim
+
+# Copy the compiled binary from the builder stage
+COPY --from=builder /usr/src/blt/target/release/blt /usr/local/bin/blt-tokenize
+
+# Set the entrypoint
+ENTRYPOINT ["blt-tokenize"]

--- a/README.md
+++ b/README.md
@@ -11,23 +11,33 @@ A high-performance, modality-agnostic byte‑level tokenizer and patching engine
 ## 🚀 Features
 
 * **Lossless Byte Coverage** – Tokenize any file as raw bytes with no unknown symbols.
-* **Configurable Quantization** – Support for Byte-Pair Encoding (BPE) merges and entropy-based patch segmentation.
+* **Configurable Quantization** – Current support for Byte-Pair Encoding (BPE) merges. Entropy-based patch segmentation is a planned feature (see Roadmap v0.2).
 * **Ultra‑High Throughput** – Async, multi-threaded architecture that auto-scales to available CPU cores and RAM.
-* **Modular & Extensible** – Pluggable strategies for BPE, patchers, and custom tokenization rules.
-* **Easy Integration** – Standalone CLI, Python bindings (via PyO3), and optional REST adapter.
+* **Modular & Extensible** – Designed for modularity. Core BPE logic is in place. Pluggable strategies for different tokenizers (like patchers) and custom rules are planned for future versions to enhance extensibility.
+* **Easy Integration** – Standalone CLI is available. Python bindings (via PyO3) and an optional REST adapter are planned (see Roadmap v0.3).
 
 ## 📦 Installation
 
-**Rust (CLI only)**
+**From Source (Rust CLI)**
 
+Currently, BLT must be built from source. Publication to crates.io is planned.
 ```bash
-cargo install blt
+git clone https://github.com/username/blt.git
+cd blt
+cargo build --release
+# The binary will be in target/release/blt
+# You can then run it as ./target/release/blt-tokenize ...
 ```
 
 **Docker**
 
+A `Dockerfile` is provided to build a Docker image locally. Official images on Docker Hub are planned.
 ```bash
-docker pull username/blt:latest
+git clone https://github.com/username/blt.git
+cd blt
+docker build -t blt-tokenizer .
+# You can then run it as:
+# docker run -i --rm blt-tokenizer --input - --output - < your_file.txt
 ```
 
 **Python (future)**
@@ -48,7 +58,7 @@ blt-tokenize \
   --output  <path/to/output>  # '-' for stdout
   --merges  <path/to/merges.txt>   # Optional BPE merges file
   --patch   <path/to/patch.yml>    # Optional patch config
-  --type    text|audio|bin    # Prepend content-type token
+  --type    text|audio|bin|video # Prepend content-type token
   --threads <num>             # Override worker count (default: detected cores)
   --memcap  <percent>         # Max RAM usage fraction (default: 80%)
   --chunksize <size>          # Min/Max chunk size (e.g. 4MB)
@@ -75,30 +85,15 @@ tokens = tok.encode_bytes(open("file.bin","rb").read())
 
 ## 📖 Documentation
 
-* Architecture & design: [Architecture.md](./Architecture.md)
-* API reference (once published): [docs/api.md](./docs/api.md)
+* Architecture & design: [ARCHITECTURE.md](./ARCHITECTURE.md)
+* API reference: Work in progress. Initial public API docs can be generated using `cargo doc --open`. A more formal `docs/api.md` is planned.
+* Contribution guidelines: [CONTRIBUTING.md](./CONTRIBUTING.md)
 
 ---
 
 ## 🤝 Contributing
 
-We welcome contributions of all kinds:
-
-1. **Clone** the repo and create a feature branch:
-
-   ```bash
-   ```
-
-git clone [https://github.com/username/blt.git](https://github.com/username/blt.git)
-cd blt
-git checkout -b feature/your-idea
-
-```
-2. **Implement** your changes, with clear tests under `tests/`.
-3. **Format** code (`cargo fmt`) and **lint** (`cargo clippy`).
-4. **Push** and open a Pull Request targeting `main`.
-
-Please review our [CONTRIBUTING.md](./CONTRIBUTING.md) for detailed guidelines.
+We welcome contributions! Please see our [CONTRIBUTING.md](./CONTRIBUTING.md) for detailed guidelines on how to set up your development environment, run tests, and submit pull requests.
 
 ---
 

--- a/blt_core/src/chunking.rs
+++ b/blt_core/src/chunking.rs
@@ -1,3 +1,12 @@
+//! # Chunking Logic for BLT
+//!
+//! This module determines the appropriate size for data chunks that are processed
+//! in parallel by the tokenizer. The goal is to balance memory usage, CPU utilization,
+//! and I/O throughput.
+//!
+//! Chunk size can be specified by the user via CLI arguments or calculated
+//! dynamically based on available system RAM and the number of processing threads.
+
 use crate::CoreConfig;
 use sysinfo::System; // Removed SystemExt from direct import
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -50,6 +50,7 @@ enum CliContentType {
     Text,
     Audio,
     Bin,
+    Video, // Added Video
 }
 
 // Conversion from CLI's ContentType to Core's ContentType
@@ -59,6 +60,7 @@ impl From<CliContentType> for CoreContentType {
             CliContentType::Text => CoreContentType::Text,
             CliContentType::Audio => CoreContentType::Audio,
             CliContentType::Bin => CoreContentType::Bin,
+            CliContentType::Video => CoreContentType::Video, // Added Video
         }
     }
 }


### PR DESCRIPTION
- Add `Video` to `ContentType` enum in `blt_core` and `CliContentType` in `src/main.rs`.
- Assign token `0xFF04` for Video type and update tests.
- Update README.md and ARCHITECTURE.md to include `video` as a CLI type option.

Docs: Initial documentation setup

- Create `CONTRIBUTING.md` with guidelines for contributors.
- Add a `Dockerfile` for building the CLI application.
- Update `README.md` to reflect current installation methods (build from source, local Docker build) and clarify feature status.
- Update `README.md` links for API docs and contributing guide.
- Add module-level documentation comments (`//!`) to `blt_core/src/lib.rs` and `blt_core/src/chunking.rs`.
- Add public API documentation comment (`///`) to `blt_core::run_tokenizer` function.